### PR TITLE
PHP 8.0 support 🚀

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
     - 7.2
     - 7.3
     - 7.4
+    - 8.0snapshot
 
 env:
     matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,3 @@ before_script:
 
 script:
   - vendor/bin/phpunit
-  - if [ "$TRAVIS_PHP_VERSION" == "5.5.9" ] || [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then vendor/bin/phpunit --coverage-clover build/logs/clover.xml; fi
-
-after_script:
-  - if [ "$TRAVIS_PHP_VERSION" == "5.5.9" ] || [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-  - if [ "$TRAVIS_PHP_VERSION" == "5.5.9" ] || [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: php
 
 php:
-    - 5.5.9
-    - 5.5
-    - 5.6
-    - 7.0
-    - hhvm
+    - 7.2
+    - 7.3
+    - 7.4
 
 env:
     matrix:

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "monolog/monolog": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0|^9.0"
+        "phpunit/phpunit": "^8.2.3|^9.0"
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,14 @@
             "Tylercd100\\Monolog\\Tests\\": "tests/"
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "monolog/monolog": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0"
+        "phpunit/phpunit": "^8.0|^9.0"
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^5.4|^7.0",
-        "monolog/monolog": "^1.11 || ^2.0"
+        "monolog/monolog": "^1.11|^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0|^5.0"

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     },
     "minimum-stability": "stable",
     "require": {
-        "php": "^5.4|^7.0",
-        "monolog/monolog": "^1.11|^2.0"
+        "php": "^7.2",
+        "monolog/monolog": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0|^5.0"
+        "phpunit/phpunit": "^5.0"
     },
     "authors": [
         {

--- a/src/Handler/MailgunHandler.php
+++ b/src/Handler/MailgunHandler.php
@@ -36,7 +36,7 @@ class MailgunHandler extends MailHandler
     /**
      * {@inheritdoc}
      */
-    protected function send($content, array $records)
+    protected function send(string $content, array $records): void
     {
         $auth = base64_encode("api:".$this->token);
 

--- a/tests/MailgunHandlerTest.php
+++ b/tests/MailgunHandlerTest.php
@@ -11,18 +11,21 @@ class MailgunHandlerTest extends TestCase
     public function testItCanBeInstantiated()
     {
         $handler = $this->createHandler("to@test.com", "Test subject", "from@test.com", "Token", "test.com");
+        $this->assertTrue(true); // Previous line doesn't thrown an exception
     }
 
     public function testItThrowsExceptionWithUnsupportedVersion()
     {
-        $this->setExpectedException(Exception::class);
-        $handler = $this->createHandler("to@test.com", "Test subject", "from@test.com", "Token", "test.com", 100,  true, 'api.mailgun.net', 'v0');
+        $this->expectException(Exception::class);
+        $handler = $this->createHandler("to@test.com", "Test subject", "from@test.com", "Token", "test.com", 100, true, 'api.mailgun.net', 'v0');
     }
 
     private function createHandler($to = "to@test.com",$subject = "Test subject",$from = "from@test.com",$token = "Token",$domain = "test.com", $level = Logger::CRITICAL, $bubble = true, $host = 'api.mailgun.net', $version = 'v3')
     {
         $constructorArgs = array($to, $subject, $from, $token, $domain, $level, $bubble, $host, $version);
         $this->handler = $this->getMockBuilder(MailgunHandler::class)
-            ->setConstructorArgs($constructorArgs)->getMock();
+            ->setMethods([])
+            ->setConstructorArgs($constructorArgs)
+            ->getMock();
     }
 }

--- a/tests/MailgunHandlerTest.php
+++ b/tests/MailgunHandlerTest.php
@@ -22,10 +22,7 @@ class MailgunHandlerTest extends TestCase
     private function createHandler($to = "to@test.com",$subject = "Test subject",$from = "from@test.com",$token = "Token",$domain = "test.com", $level = Logger::CRITICAL, $bubble = true, $host = 'api.mailgun.net', $version = 'v3')
     {
         $constructorArgs = array($to, $subject, $from, $token, $domain, $level, $bubble, $host, $version);
-        $this->handler = $this->getMock(
-            '\Tylercd100\Monolog\Handler\MailgunHandler',
-            array(),
-            $constructorArgs
-        );
+        $this->handler = $this->getMockBuilder(MailgunHandler::class)
+            ->setConstructorArgs($constructorArgs)->getMock();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,8 +12,9 @@
 namespace Tylercd100\Monolog\Tests;
 
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends PHPUnitTestCase
 {
     /**
      * @return array Record


### PR DESCRIPTION
* Add PHP 7.2, 7.3, 7.4 and 8.0 support
* Upgrade from Monolog 1.11 to 2.0
* Update PHPUnit tests
* Drop PHP 5.4, 5.5, 5.6, 7.0 and 7.1 support

If this pull request is merged, can you tag it with the `3.0.0` version, please?

Credits to @robbielove for the initial work 👍